### PR TITLE
m3 Syntax Sugar

### DIFF
--- a/plio/io/io_moon_minerology_mapper.py
+++ b/plio/io/io_moon_minerology_mapper.py
@@ -2,6 +2,15 @@ import os
 import numpy as np
 from .io_gdal import GeoDataset
 from .hcube import HCube
+
+try:
+    from libpysat.derived import m3, crism
+    from libpysat.derived.utils import add_derived_funcs
+    libpysat_enabled = True
+except:
+    print('No libpysat module. Unable to attached derived product functions')
+    libpysat_enabled = False
+
 import gdal
 
 
@@ -9,6 +18,24 @@ class M3(GeoDataset, HCube):
     """
     An M3 specific reader with the spectral mixin.
     """
+    def __init__(self, file_name):
+
+        GeoDataset.__init__(self, file_name)
+        HCube.__init__(self)
+
+        if libpysat_enabled:
+            self.derived_funcs = add_derived_funcs(m3)
+
+    def __getattr__(self, name):
+        try:
+            func = self.derived_funcs[name]
+
+            setattr(self, name, func.__get__(self))
+            return getattr(self, name)
+
+        except:
+            raise AttributeError()
+
     @property
     def wavelengths(self):
         if not hasattr(self, '_wavelengths'):


### PR DESCRIPTION
Allows derived products to be called on m3 objects as if the derived functions are part of the m3 object. Needs a little work but this is what I have for this so far. Closes USGS-Astrogeology/PySAT#110