### PR TITLE
Updates build string to have build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,7 @@ source:
   git_url: https://github.com/USGS-Astrogeology/plio
 
 build:
-  number: {{ GIT_DESCRIBE_NUMBER }}
-  string: dev
+  string: "{{ GIT_DESCRIBE_NUMBER }}_dev"
 
 extra:
   channels:


### PR DESCRIPTION
New name: `plio-1.2.1-6_dev.tar.bz2`