### PR TITLE
Updates control network IO to convert to 0 based pixels

### DIFF
--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -169,7 +169,7 @@ class IsisStore(object):
             self._handle.seek(point_start_byte)
             cp = cnp5.ControlPointFileEntryV0005()
             pts = []
-            byte_count = 0;
+            byte_count = 0
             while byte_count < find_in_dict(pvl_header, 'PointsBytes'):
                 message_size = struct.unpack('I', self._handle.read(4))[0]
                 cp.ParseFromString(self._handle.read(message_size))
@@ -185,6 +185,9 @@ class IsisStore(object):
 
         cols = self.point_attrs + self.measure_attrs
         df = IsisControlNetwork(pts, columns=cols)
+        # Convert the (0.5, 0.5) origin pixels back to (0,0) pixels
+        df['line'] -= 0.5
+        df['sample'] -= 0.5
         df.header = pvl_header
         return df
 

--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -259,8 +259,9 @@ class IsisStore(object):
                     if attr in g.columns:
                         setattr(measure_spec, attr, attrtype(m[attr]))
                 measure_spec.serialnumber = m.serialnumber
-                measure_spec.sample = m.x
-                measure_spec.line = m.y
+                # ISIS pixels are centered on (0.5, 0.5). NDArrays are (0,0) based.
+                measure_spec.sample = m.x + 0.5 
+                measure_spec.line = m.y + 0.5
                 measure_spec.type = m.measuretype
                 measure_iterable.append(measure_spec)
                 self.nmeasures += 1


### PR DESCRIPTION
So the most terrifying thing in doing this is that all of the tests still passed locally....

The socet items are in the bin dir. I want to talk to @dpmayerUSGS about what the soccer origin and pixel origins are before touching those files at all.  The current conversion code is handling an origin and a pixel origin shift all at once and I'm not that brave.