### PR TITLE
shifting apriori line/sample during read in/write out

### DIFF
--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -208,6 +208,8 @@ class IsisStore(object):
         # Convert the (0.5, 0.5) origin pixels back to (0,0) pixels
         df['line'] -= 0.5
         df['sample'] -= 0.5
+        df['aprioriline'] -= 0.5
+        df['apriorisample'] -= 0.5
         df.header = pvl_header
         return df
 
@@ -295,6 +297,8 @@ class IsisStore(object):
                 # ISIS pixels are centered on (0.5, 0.5). NDArrays are (0,0) based.
                 measure_spec.sample = m['sample'] + 0.5
                 measure_spec.line = m['line'] + 0.5
+                measure_spec.sample = m['apriorisample'] + 0.5
+                measure_spec.line = m['aprioriline'] + 0.5
                 measure_iterable.append(measure_spec)
                 self.nmeasures += 1
 

--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -208,8 +208,9 @@ class IsisStore(object):
         # Convert the (0.5, 0.5) origin pixels back to (0,0) pixels
         df['line'] -= 0.5
         df['sample'] -= 0.5
-        df['aprioriline'] -= 0.5
-        df['apriorisample'] -= 0.5
+        if 'aprioriline' in df.columns:
+            df['aprioriline'] -= 0.5
+            df['apriorisample'] -= 0.5
         df.header = pvl_header
         return df
 
@@ -297,8 +298,9 @@ class IsisStore(object):
                 # ISIS pixels are centered on (0.5, 0.5). NDArrays are (0,0) based.
                 measure_spec.sample = m['sample'] + 0.5
                 measure_spec.line = m['line'] + 0.5
-                measure_spec.sample = m['apriorisample'] + 0.5
-                measure_spec.line = m['aprioriline'] + 0.5
+                if 'apriorisample' in g.columns:
+                    measure_spec.apriorisample = m['apriorisample'] + 0.5
+                    measure_spec.aprioriline = m['aprioriline'] + 0.5
                 measure_iterable.append(measure_spec)
                 self.nmeasures += 1
 


### PR DESCRIPTION
Line and sample values were getting converted to/from (0.5, 0.5) from/to (0, 0) datum during write out and read in, respectively, but aprioriline/sample were note being touched. This resulted in an increase shift metric when viewing in qnet.

This is a simple PR that include aprioriline/sample in the same shifts line/sample go through.