### PR TITLE
Fixes 144

### DIFF
--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -63,7 +63,6 @@ class MeasureLog():
             self.messagetype = MeasureMessageType(messagetype)
         else:
             # by name
-            print(MeasureMessageType[messagetype])
             self.messagetype = MeasureMessageType[messagetype]
         
         if not isinstance(value, (float, int)):
@@ -73,7 +72,7 @@ class MeasureLog():
     def __repr__(self):
         return f'{self.messagetype.name}: {self.value}'
         
-    def to_protobuf(self):
+    def to_protobuf(self, version=2):
         """
         Return protobuf compliant measure log object representation
         of this class.
@@ -87,7 +86,10 @@ class MeasureLog():
         # I do not see a better way to get to the inner MeasureLogData obj than this
         # imports were not working because it looks like these need to instantiate off
         # an object
-        log_message = cnf.ControlPointFileEntryV0002().Measure().MeasureLogData()
+        if version == 2:
+            log_message = cnf.ControlPointFileEntryV0002().Measure().MeasureLogData()
+        elif version == 5:
+            log_message = cnp5.ControlPointFileEntryV0005().Measure().MeasureLogData()
         log_message.doubleDataValue = self.value
         log_message.doubleDataType = self.messagetype
         return log_message

--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -34,6 +34,9 @@ def write_filelist(lst, path="fromlist.lis"):
 
 
 class MessageType(IntEnum):
+    """
+    An enum to mirror the ISIS3 MeasureLogData enum.
+    """
     GoodnessOfFit = 2
     MinimumPixelZScore = 3
     MaximumPixelZScore = 4
@@ -60,10 +63,11 @@ class Log():
             self.messagetype = MessageType(messagetype)
         else:
             # by name
+            print(MessageType[messagetype])
             self.messagetype = MessageType[messagetype]
         
         if not isinstance(value, (float, int)):
-            raise TypeError(f'{x} is not a numeric type')
+            raise TypeError(f'{value} is not a numeric type')
         self.value = value
         
     def __repr__(self):

--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -33,7 +33,7 @@ def write_filelist(lst, path="fromlist.lis"):
     return
 
 
-class MessageType(IntEnum):
+class MeasureMessageType(IntEnum):
     """
     An enum to mirror the ISIS3 MeasureLogData enum.
     """
@@ -44,27 +44,27 @@ class MessageType(IntEnum):
     WholePixelCorrelation = 6
     SubPixelCorrelation = 7 
 
-class Log():
+class MeasureLog():
     
     def __init__(self, messagetype, value):
         """
-        A protobuf compliant log object.
+        A protobuf compliant measure log object.
         
         Parameters
         ----------
         messagetype : int or str
-                      Either the integer or string representation from the MessageType enum
+                      Either the integer or string representation from the MeasureMessageType enum
                       
         value : int or float
                 The value to be stored in the message log
         """
         if isinstance(messagetype, int):
             # by value
-            self.messagetype = MessageType(messagetype)
+            self.messagetype = MeasureMessageType(messagetype)
         else:
             # by name
-            print(MessageType[messagetype])
-            self.messagetype = MessageType[messagetype]
+            print(MeasureMessageType[messagetype])
+            self.messagetype = MeasureMessageType[messagetype]
         
         if not isinstance(value, (float, int)):
             raise TypeError(f'{value} is not a numeric type')
@@ -280,7 +280,7 @@ class IsisStore(object):
             df['apriorisample'] -= 0.5
 
         # Munge the MeasureLogData into Python objs
-        df['measureLog'] = df['measureLog'].apply(lambda x: [Log.from_protobuf(i) for i in x])
+        df['measureLog'] = df['measureLog'].apply(lambda x: [MeasureLog.from_protobuf(i) for i in x])
         
         df.header = pvl_header
         return df

--- a/plio/io/tests/test_io_controlnetwork.py
+++ b/plio/io/tests/test_io_controlnetwork.py
@@ -31,6 +31,38 @@ def test_cnet_read(cnet_file):
         assert proto_field not in df.columns
         assert mangled_field in df.columns
 
+@pytest.mark.parametrize('messagetype, value', [
+                         (2, 0.5),
+                         (3, 0.5),
+                         (4, -0.25),
+                         (5, 1e6),
+                         (6, 1),
+                         (7, -1e10),
+                         ('GoodnessOfFit', 0.5),
+                         ('MinimumPixelZScore', 0.25)
+])
+def test_Log(messagetype, value):
+    l = io_controlnetwork.Log(messagetype, value)
+    if isinstance(messagetype, int):
+        assert l.messagetype == io_controlnetwork.MessageType(messagetype)
+    elif isinstance(messagetype, str):
+        assert l.messagetype == io_controlnetwork.MessageType[messagetype]
+        
+    assert l.value == value
+    assert isinstance(l.to_protobuf, object)
+
+def test_log_error():
+    with pytest.raises(TypeError) as err:
+        io_controlnetwork.Log(2, 'foo')
+
+def test_to_protobuf():
+    value = 1.25
+    int_dtype = 2
+    log = io_controlnetwork.Log(int_dtype, value)
+    proto = log.to_protobuf()
+    assert proto.doubleDataType == int_dtype
+    assert proto.doubleDataValue == value
+
 class TestWriteIsisControlNetwork(unittest.TestCase):
 
     @classmethod

--- a/plio/io/tests/test_io_controlnetwork.py
+++ b/plio/io/tests/test_io_controlnetwork.py
@@ -41,24 +41,24 @@ def test_cnet_read(cnet_file):
                          ('GoodnessOfFit', 0.5),
                          ('MinimumPixelZScore', 0.25)
 ])
-def test_Log(messagetype, value):
-    l = io_controlnetwork.Log(messagetype, value)
+def test_MeasureLog(messagetype, value):
+    l = io_controlnetwork.MeasureLog(messagetype, value)
     if isinstance(messagetype, int):
-        assert l.messagetype == io_controlnetwork.MessageType(messagetype)
+        assert l.messagetype == io_controlnetwork.MeasureMessageType(messagetype)
     elif isinstance(messagetype, str):
-        assert l.messagetype == io_controlnetwork.MessageType[messagetype]
+        assert l.messagetype == io_controlnetwork.MeasureMessageType[messagetype]
         
     assert l.value == value
     assert isinstance(l.to_protobuf, object)
 
 def test_log_error():
     with pytest.raises(TypeError) as err:
-        io_controlnetwork.Log(2, 'foo')
+        io_controlnetwork.MeasureLog(2, 'foo')
 
 def test_to_protobuf():
     value = 1.25
     int_dtype = 2
-    log = io_controlnetwork.Log(int_dtype, value)
+    log = io_controlnetwork.MeasureLog(int_dtype, value)
     proto = log.to_protobuf()
     assert proto.doubleDataType == int_dtype
     assert proto.doubleDataValue == value


### PR DESCRIPTION
This supports reads and writes. I need to do some tests but the logic for reading/writing is in.

Example usage (outside autocnet, since autocnet will just consume this API down the line):

```python
from plio.io.io_controlnetwork import from_isis, to_isis, Log
innet = from_isis('/scratch/jlaura/14_334_to_18_335/firstpass.net')

l = Log(3, 0.15)
m = Log(2, 0.5)
innet.iloc[0].measureLog.append(l)
innet.iloc[0].measureLog.append(m)

innet.iloc[0].measureLog
```

Results in: `[MinimumPixelZScore: 0.15, GoodnessOfFit: 0.5]` because of the `__repr__`. They are Log Objects. 

