### PR TITLE
Add label to dev builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ after_success:
   - travis_wait builddir=(`conda build recipe --output`)
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      anaconda -t="$CONDA_UPLOAD_TOKEN" upload $builddir --force;
+      anaconda -t="$CONDA_UPLOAD_TOKEN" upload -l dev --force $builddir;
     fi
 
   # Docs to gh-pages


### PR DESCRIPTION
This will help make it clear that the dev builds are not the last released version of the code, but the current dev.

Fixes #154 