### PR TITLE
Adds .readthedocs.yaml file for new ReadTheDocs builds.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+conda:
+  environment: environment.yml
+

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ We maintain a development branch of plio that is used as a staging area for our 
 
 [![Coverage Status](https://coveralls.io/repos/github/USGS-Astrogeology/plio/badge.svg?branch=master)](https://coveralls.io/github/USGS-Astrogeology/plio?branch=master)
 
+[![Documentation Status](https://readthedocs.org/projects/plio/badge/?version=latest)](https://plio.readthedocs.io/en/latest/?badge=latest)
+
 To install the development version: 
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Current build status
 [![OSX](https://img.shields.io/travis/conda-forge/plio-feedstock/master.svg?label=macOS)](https://travis-ci.org/conda-forge/plio-feedstock)
 [![Windows](https://img.shields.io/appveyor/ci/conda-forge/plio-feedstock/master.svg?label=Windows)](https://ci.appveyor.com/project/conda-forge/plio-feedstock/branch/master)
 
+[![Documentation Status](https://readthedocs.org/projects/plio/badge/?version=latest)](https://plio.readthedocs.io/en/latest/?badge=latest)
+
 Current release info
 ====================
 
@@ -47,7 +49,6 @@ We maintain a development branch of plio that is used as a staging area for our 
 
 [![Coverage Status](https://coveralls.io/repos/github/USGS-Astrogeology/plio/badge.svg?branch=master)](https://coveralls.io/github/USGS-Astrogeology/plio?branch=master)
 
-[![Documentation Status](https://readthedocs.org/projects/plio/badge/?version=latest)](https://plio.readthedocs.io/en/latest/?badge=latest)
 
 To install the development version: 
 

--- a/docs/users/tutorials/index.rst
+++ b/docs/users/tutorials/index.rst
@@ -1,5 +1,5 @@
-Getting Started with AutoCNet
-=============================
+Getting Started with Plio
+=========================
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This PR: 
* Adds a new .readthedocs.yaml file for ReadTheDocs builds (see: https://docs.readthedocs.io/en/stable/config-file/v2.html. This seems to be recommended.)
* Fixes the tutorial's title
* Adds a badge for the documentation build to the README.md