### PR TITLE
Allows the user (or CI) to grab gdal from osgeo instead, if available

### DIFF
--- a/plio/io/io_gdal.py
+++ b/plio/io/io_gdal.py
@@ -11,7 +11,13 @@ import pvl
 from plio.io import extract_metadata, conditional_gdal
 from plio.geofuncs import geofuncs
 from plio.utils.utils import find_in_dict
-from plio.io import gdal, ogr, osr
+from plio.io import osgeo, ogr, osr
+
+if not gdal:
+    try:
+        from osgeo import gdal
+    except:
+        raise ImportError('No module name gdal in plio or osgeo.')
 
 NP2GDAL_CONVERSION = {
   "byte": 1,
@@ -146,8 +152,6 @@ class GeoDataset(object):
 
         """
         self.file_name = file_name
-        if not gdal:
-            raise ImportError('No module name gdal.')
         self.dataset = gdal.Open(file_name)
         if self.dataset is None:
           raise IOError('File not found :', file_name)


### PR DESCRIPTION
For some reason, Travis-CI fails to import gdal from plio.io in PyHAT testing, even when this import works just fine outside of the testing environment. Local pytesting of PyHAT shows that Travis-CI can retrieve gdal successfully by importing it from osgeo. So this is a little bit of a bandaid that seems to work locally.