### PR TITLE
Update CI Python versions

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
        os: [ubuntu-latest, macos-latest]
-       python-version: ["3.6", "3.7", "3.8"]   
+       python-version: ["3.7", "3.8", "3.9", "3.10"]   
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Python 3.6 is EoL and conda-forge is onto 3.10 so we should start testing Python 3.7-3.10