### PR TITLE
removed gdal as a requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,8 @@ requirements:
     - scipy
     - certifi
     - pyproj
+  run_contrained: 
+    - gdal 
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - numpy
     - pvl >= 1.3.0
     - protobuf
-    - gdal
     - icu
     - h5py
     - pandas
@@ -38,7 +37,6 @@ requirements:
     - numpy
     - pvl >= 1.3.0
     - protobuf
-    - gdal
     - icu
     - h5py
     - pandas

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,11 @@ def setup_package():
         zip_safe=True,
         scripts=['bin/socetnet2isis', 'bin/isisnet2socet'],
         install_requires=[
-            'gdal',
             'numpy',
             'pyproj',
             'pvl',
-            'protobuf',
             'h5py',
+            'protobuf',
             'pandas',
             'sqlalchemy',
             'pyyaml',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ def setup_package():
             'networkx',
             'affine',
             'scipy'],
+        extras_require={'io_gdal' : "gdal"},
         classifiers=[
             "Development Status :: 3 - Alpha",
             "Topic :: Utilities",


### PR DESCRIPTION
This should make it easier to not require GDAL in the conda-forge recipe. 

confirmed working by installing plio onto the same env as ISIS without requiring GDAL. 