### PR TITLE
Pvl 1.3.0 Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ release.
 ## [Unreleased]
 
 ### Fixed
-- Updated `create_pvl_header()` to add a newline (`\n`) character to the end of the pvl string. This ensures that the controls networks can be read back in using pvl 1.3.0 [#193](https://github.com/USGS-Astrogeology/plio/pull/193)
+- Updated `create_pvl_header()` to add a newline (`\n`) character to the end of the pvl string. This ensures that the control networks written, then read back in using pvl 1.3.0 [#193](https://github.com/USGS-Astrogeology/plio/pull/193)
 
 ## [1.5.3]()
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ release.
 ## [Unreleased]
 
 ### Fixed
-- Updated `create_pvl_header()` at add a newline (`\n`) character to the end of the pvl string. This ensures that the controls networks can be read in pvl 1.3.0 [#193](https://github.com/USGS-Astrogeology/plio/pull/193)
+- Updated `create_pvl_header()` to add a newline (`\n`) character to the end of the pvl string. This ensures that the controls networks can be read back in using pvl 1.3.0 [#193](https://github.com/USGS-Astrogeology/plio/pull/193)
 
 ## [1.5.3]()
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ release.
 ## [Unreleased]
 
 ### Fixed
-- Updated `create_pvl_header()` to add a newline (`\n`) character to the end of the pvl string. This ensures that the control networks written, then read back in using pvl 1.3.0 [#193](https://github.com/USGS-Astrogeology/plio/pull/193)
+- Updated `create_pvl_header()` to add a newline (`\n`) character to the end of the pvl string. This ensures that the control networks can be written, then read back in using pvl 1.3.0 [#193](https://github.com/USGS-Astrogeology/plio/pull/193)
 
 ## [1.5.3]()
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+- Updated `create_pvl_header()` at add a newline (`\n`) character to the end of the pvl string. This ensures that the controls networks can be read in pvl 1.3.0 [#193](https://github.com/USGS-Astrogeology/plio/pull/193)
 
 ## [1.5.3]()
 ### Fixed

--- a/plio/io/io_controlnetwork.py
+++ b/plio/io/io_controlnetwork.py
@@ -224,7 +224,7 @@ class IsisStore(object):
         Given an ISIS store, read the underlying ISIS3 compatible control network and
         return an IsisControlNetwork dataframe.
         """
-        pvl_header = pvl.load(self._path, grammar=pvl.grammar.ISISGrammar())
+        pvl_header = pvl.load(self._path)
         header_start_byte = find_in_dict(pvl_header, 'HeaderStartByte')
         header_bytes = find_in_dict(pvl_header, 'HeaderBytes')
         point_start_byte = find_in_dict(pvl_header, 'PointsStartByte')
@@ -499,4 +499,4 @@ class IsisStore(object):
                  )
         ])
 
-        return pvl.dumps(header, encoder=encoder)
+        return pvl.dumps(header, encoder=encoder) + "\n"


### PR DESCRIPTION
Fixed pvl writing in Plio for pvl = 1.3.0

Having extra data after the PVL header created read problems when ingesting control networks written out by plio. This adds a `\n` character to the end of the header. This tells pvl to terminate after reading the header.

Tested this locally with both pvl=1.3.0 and 1.3.2, both work as expected.

Related to [this issue in ISIS](https://github.com/USGS-Astrogeology/ISIS3/issues/4685) and [this issue](https://github.com/planetarypy/pvl/issues/98) in PVL