### PR TITLE
Bumps for 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,14 +35,16 @@ release.
 
 ## [Unreleased]
 
+# [1.6.2]()
+
+### Changed
+- Changed protobuf dependency to 4.Y.Z and regenerated protobuf files [#217](https://github.com/DOI-USGS/plio/pull/217)
+
 # [1.6.1]() 
 
 ### Fixed
 - Fixed a bug in which prefixes and suffixes were not properly prepended/appended to point_id [#213](https://github.com/DOI-USGS/plio/issues/213)
 - Fixed a deprecation warning by changing to importlib tools for version determination [#218](https://github.com/DOI-USGS/plio/issues/218)
-
-### Changed
-- Changed protobuf dependency to 4.Y.Z and regenerated protobuf files [#217](https://github.com/DOI-USGS/plio/pull/217)
 
 # [1.6.0]()
 

--- a/code.json
+++ b/code.json
@@ -47,6 +47,46 @@
       "name": "plio",
       "organization": "U.S. Geological Survey",
       "description": "A planetary surface data input/output library written in Python.",
+      "version": "v1.6.2",
+      "status": "Development",
+      "permissions": {
+        "usageType": "openSource",
+        "licenses": [
+          {
+            "name": "Public Domain, CC0-1.0",
+            "URL": "https://code.usgs.gov/astrogeology/plio/-/raw/v1.6.2/LICENSE.md"
+          }
+        ]
+      },
+      "homepageURL": "https://plio.readthedocs.io/en/latest/?badge=latest",
+      "downloadURL": "https://code.usgs.gov/astrogeology/plio/-/archive/v1.6.2/plio-v1.6.2.zip",
+      "disclaimerURL": "https://code.usgs.gov/astrogeology/plio/-/raw/v1.6.2/DISCLAIMER.md",
+      "repositoryURL": "https://code.usgs.gov/astrogeology/plio.git",
+      "vcs": "git",
+      "laborHours": 1000,
+      "tags": [
+        "Planetary",
+        "Remote Sensing",
+        "Photogrammetry",
+        "Data Processing"
+      ],
+  
+      "languages": [
+        "python"
+      ],
+  
+      "contact": {
+        "name": "Adam Paquette",
+        "email": "acpaquette@usgs.gov"
+      },
+  
+      "date": {
+        "metadataLastUpdated": "2025-08-15"
+      }
+    }, {
+      "name": "plio",
+      "organization": "U.S. Geological Survey",
+      "description": "A planetary surface data input/output library written in Python.",
       "version": "v1.6.1",
       "status": "Development",
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as f:
 def setup_package():
     setup(
         name = "plio",
-        version = '1.6.1',
+        version = '1.6.2',
         author = "USGS Astrogeology",
         author_email = "jlaura@usgs.gov",
         description = ("I/O API to support planetary data formats."),


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

